### PR TITLE
Add D2 Diagrams plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Commands Marketplace](https://github.com/ananddtyagi/claude-code-marketplace) - Community marketplace for Claude Code commands and plugins; add with `/plugin marketplace add ananddtyagi/claude-code-marketplace`.
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
+- [D2 Diagrams](https://github.com/heathdutton/claude-d2-diagrams) - Generates infrastructure and architecture diagrams from codebases using D2; scans Terraform, K8s, Docker, CloudFormation to produce themed SVGs with icons.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
 
 ## MCP Servers


### PR DESCRIPTION
### **User description**
Adds [claude-d2-diagrams](https://github.com/heathdutton/claude-d2-diagrams) to the Plugins & Extensions section.

Generates infrastructure and architecture diagrams from codebases using [D2](https://d2lang.com/). Scans Terraform, K8s, Docker, CloudFormation to produce light/dark themed SVGs with service icons.


___

### **PR Type**
Documentation


___

### **Description**
- Adds D2 Diagrams plugin to Plugins & Extensions section

- Plugin generates infrastructure and architecture diagrams from codebases

- Supports Terraform, K8s, Docker, CloudFormation scanning

- Produces themed SVGs with service icons


___

### Diagram Walkthrough


```mermaid
flowchart LR
  README["README.md"] -- "adds plugin entry" --> D2["D2 Diagrams Plugin"]
  D2 -- "generates diagrams from" --> IaC["Infrastructure Code<br/>Terraform, K8s, Docker,<br/>CloudFormation"]
  D2 -- "produces" --> SVG["Themed SVG Output<br/>with Icons"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add D2 Diagrams plugin documentation entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds D2 Diagrams plugin entry to Plugins & Extensions section<br> <li> Includes link to claude-d2-diagrams GitHub repository<br> <li> Describes plugin functionality for generating infrastructure diagrams<br> <li> Lists supported infrastructure-as-code formats and output features</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/awesome-claude-code/pull/5/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

