### PR TITLE
Add Synod - Multi-Agent Deliberation Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
+- [Synod](https://github.com/quantsquirrel/claude-synod-debate) - Research-backed multi-agent deliberation system. Claude, Gemini, and OpenAI debate for better decision-making.
 
 ## MCP Servers
 - [Atlassian Remote MCP Server](https://developer.atlassian.com/platform/model-context-protocol/) - OAuth-secured remote MCP for Jira/Confluence (Claude setup + cloud endpoints).


### PR DESCRIPTION
### **User description**
## Summary

Add Synod to the Plugins & Extensions section.

**Synod** is a research-backed multi-agent deliberation system that enables Claude, Gemini, and OpenAI to debate for better decision-making.

## Changes
- Added Synod entry to the "Plugins & Extensions" section
- Entry includes repository link and concise description

Repository: https://github.com/quantsquirrel/claude-synod-debate

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added Synod plugin entry to README

- Multi-agent deliberation system for Claude, Gemini, OpenAI

- Includes repository link and feature description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  README["README.md"] -- "Add Synod entry" --> Plugins["Plugins & Extensions Section"]
  Plugins -- "Link to repository" --> Synod["Synod: Multi-Agent Deliberation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add Synod plugin documentation entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added Synod plugin entry to the Plugins & Extensions section<br> <li> Included repository link to quantsquirrel/claude-synod-debate<br> <li> Added description highlighting multi-agent debate capabilities<br> <li> Positioned between Docker Claude Plugins and MCP Servers sections</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/awesome-claude-code/pull/9/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

