### PR TITLE
Add MyVibe - Instant publishing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
+- [MyVibe](https://www.myvibe.so) - Instant publishing skill for Claude Code. Deploy projects to live URLs with `/myvibe:publish`. Auto-detects project type (HTML, Vite, React, Next.js) and handles builds automatically.
 
 ## MCP Servers
 - [Atlassian Remote MCP Server](https://developer.atlassian.com/platform/model-context-protocol/) - OAuth-secured remote MCP for Jira/Confluence (Claude setup + cloud endpoints).


### PR DESCRIPTION
Adding MyVibe to Plugins & Extensions. Deploy Claude Code projects to live URLs with `/myvibe:publish`. Website: https://www.myvibe.so