### PR TITLE
Add AgentStore plugin marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
+- [AgentStore](https://github.com/techgangboss/agentstore) - Open-source plugin marketplace with gasless USDC payments. Browse, install, and publish plugins via native `/plugin marketplace add` or CLI. Publishers earn 80% of sales. Agent-first API for zero-auth publishing.
 
 ## MCP Servers
 - [Atlassian Remote MCP Server](https://developer.atlassian.com/platform/model-context-protocol/) - OAuth-secured remote MCP for Jira/Confluence (Claude setup + cloud endpoints).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
-- [AgentStore](https://github.com/techgangboss/agentstore) - Open-source plugin marketplace with gasless USDC payments. Browse, install, and publish plugins via native `/plugin marketplace add` or CLI. Publishers earn 80% of sales. Agent-first API for zero-auth publishing.
+- [AgentStore](https://github.com/techgangboss/agentstore) - Open-source plugin marketplace with gasless USDC payments and an agent-first API for publishing.
 
 ## MCP Servers
 - [Atlassian Remote MCP Server](https://developer.atlassian.com/platform/model-context-protocol/) - OAuth-secured remote MCP for Jira/Confluence (Claude setup + cloud endpoints).


### PR DESCRIPTION
## Summary

- Adds [AgentStore](https://github.com/techgangboss/agentstore) to the Plugins & Extensions section
- AgentStore is an open-source plugin marketplace with gasless USDC payments (x402 protocol)
- Publishers earn 80% of sales; plugins install via `/plugin marketplace add` or CLI

## Details

AgentStore provides:
- Native Claude Code plugin marketplace integration
- Gasless USDC payments via EIP-3009 transferWithAuthorization
- 3-field API for zero-auth publishing
- CLI (`agentstore install`) and web interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)