### PR TITLE
Add Claude Forge — oh-my-zsh for Claude Code (11 agents, 36 commands, 15 skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Many resources can be installed directly via Claude Code commands:
 ## Plugins & Extensions
 - [Claude Code Commands Marketplace](https://github.com/ananddtyagi/claude-code-marketplace) - Community marketplace for Claude Code commands and plugins; add with `/plugin marketplace add ananddtyagi/claude-code-marketplace`.
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
+- [Claude Forge](https://github.com/sangrokjung/claude-forge) - oh-my-zsh for Claude Code: 11 agents, 36 slash commands, 15 skill workflows, 14 automation hooks, 6-layer security. 5-min install.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
 


### PR DESCRIPTION
## Add: Claude Forge

### Description

**Claude Forge** transforms Claude Code into a full-featured development environment — the same way oh-my-zsh transforms a plain terminal.

### Key features

- **11 specialized agents**: planner, architect, code-reviewer, security-reviewer, tdd-guide, build-error-resolver, refactor-cleaner, doc-updater, and more
- **36 slash commands**: `/commit`, `/review-pr`, `/brainstorm`, `/handoff-verify`, `/ultrawork`, and more
- **15 skill workflows**: TDD red-green cycles, SDD review pipelines, git workflows
- **14 automation hooks**: pre/post-edit security checks, auto-formatting, compliance gating
- **6-layer security system**: OWASP-aligned rules baked in from day one

### Install

```bash
bash <(curl -sL https://raw.githubusercontent.com/sangrokjung/claude-forge/main/install.sh)
```

Symlink-based installation means `git pull` updates everything instantly.

### Repository details

| Field | Value |
|-------|-------|
| URL | https://github.com/sangrokjung/claude-forge |
| License | MIT |
| Stars | 279+ (Feb 2026) |
| Language | Shell / Markdown |

### Checklist

- [x] Resource is publicly accessible
- [x] Actively maintained (commits within last 30 days)
- [x] MIT licensed
- [x] Unique — not yet listed in this repository
- [x] Description is accurate and non-promotional in tone