### PR TITLE
Add ScreenHand — desktop + browser automation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Many resources can be installed directly via Claude Code commands:
 - [GitHub MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github) - Official first-party server to read repos, manage issues/PRs, and automate workflows.
 - [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) - Community server with Sheets/Drive/Gmail/Calendar/Docs/Slides/Tasks coverage with remote OAuth and 1-click Claude install.
 - [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) - Official hosted server with OAuth; designed for Claude/Cursor/etc.
+- [ScreenHand](https://github.com/manushi4/Screenhand) - Native desktop + browser automation MCP server with 82 tools. Gives Claude Code eyes and hands on the desktop via accessibility APIs (macOS/Windows) and Chrome DevTools Protocol.
 - [Supabase MCP Server](https://supabase.com/blog/supabase-mcp) - Official server to connect Claude to Supabase projects; HTTP/SSE transports and OAuth supported.
 
 ## Editor Plugins


### PR DESCRIPTION
Adds ScreenHand to the MCP Servers section.

**ScreenHand** gives Claude Code native desktop control + browser automation via 82 MCP tools:
- Accessibility APIs (macOS Swift / Windows C#)
- Chrome DevTools Protocol with anti-detection
- Memory, jobs, supervisor, and reusable playbooks for 10 platforms

[GitHub](https://github.com/manushi4/Screenhand) | [npm](https://www.npmjs.com/package/screenhand)