### PR TITLE
Add Beacon: semantic code search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
+- [Beacon](https://github.com/sagarmk/beacon-plugin) - Semantic code search plugin using hybrid search with embeddings and BM25 keyword matching. Indexes locally via Ollama, stores in SQLite with sqlite-vec and FTS5.
 
 ## MCP Servers
 - [Atlassian Remote MCP Server](https://developer.atlassian.com/platform/model-context-protocol/) - OAuth-secured remote MCP for Jira/Confluence (Claude setup + cloud endpoints).


### PR DESCRIPTION
Adds [Beacon](https://github.com/sagarmk/beacon-plugin) to the Plugins & Extensions section.

Beacon is a semantic code search plugin for Claude Code using hybrid search with embeddings and BM25 keyword matching. It indexes locally via Ollama, stores in SQLite with sqlite-vec and FTS5, and auto-syncs via Claude Code lifecycle hooks.

Key features:
- Hybrid search: semantic embeddings + BM25 keyword matching + identifier boosting
- Fully local by default via Ollama (nomic-embed-text, mxbai-embed-large)
- Auto-indexes via Claude Code lifecycle hooks (SessionStart, PostToolUse)
- SQLite storage with sqlite-vec and FTS5
- Install: claude plugin marketplace add sagarmk/Claude-Code-Beacon-Plugin