### PR TITLE
Add fractal — recursive project management plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Many resources can be installed directly via Claude Code commands:
 ## Plugins & Extensions
 - [Claude Code Commands Marketplace](https://github.com/ananddtyagi/claude-code-marketplace) - Community marketplace for Claude Code commands and plugins; add with `/plugin marketplace add ananddtyagi/claude-code-marketplace`.
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
+- [fractal](https://github.com/rmolines/fractal) - Recursive project management for Claude Code. One primitive that decomposes any goal into verifiable predicates, works on the riskiest unknown first. Includes `/fractal:run` (idempotent state machine), `/fractal:init`, `/fractal:patch`, dry run mode, and incremental decomposition with re-evaluation.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
 


### PR DESCRIPTION
## Summary

Adds [fractal](https://github.com/rmolines/fractal) to the **Plugins & Extensions** section.

**What it does:** Recursive project management for Claude Code. One primitive that decomposes any goal into verifiable predicates, works on the riskiest unknown first. The filesystem is the state — no database, no JSON.

**Key features:**
- `/fractal:run` — idempotent state machine, call repeatedly to advance the tree
- `/fractal:init` — bootstrap any goal into a predicate tree
- `/fractal:patch` — fast path for trivial leaf predicates
- Full sprint cycle: planning → delivery → review → ship
- Dry run mode — builds the full decomposition tree without executing
- Incremental decomposition with re-evaluation at each node

**Repo:** https://github.com/rmolines/fractal