### PR TITLE
Add Pulse — local HTTP Channel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Many resources can be installed directly via Claude Code commands:
 - [Claude Code Plugins (jeremylongshore)](https://github.com/jeremylongshore/claude-code-plugins) - Marketplace-style repo bundling instruction-template plugins and MCP plugin packs, with install docs.
 - [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) - 19 production-grade plugins for trading, swarm intelligence, and GitHub automation built from 68+ specialized agents. Includes quantitative trading systems, DSPy research pipelines, distributed consensus protocols, and multi-agent swarm coordination; add with `/plugin marketplace add jmanhype/claude-code-plugins`.
 - [Docker Claude Plugins](https://github.com/docker/claude-plugins) - Integrates Docker Desktop's MCP Toolkit as a Claude Code plugin to expose containerized MCP servers through Claude.
+- [Pulse](https://github.com/chsm04/pulse) - Local Channel plugin that pushes notifications into Claude Code sessions via HTTP POST. No Discord, no Slack, just curl; install with `/plugin marketplace add chsm04/pulse`.
 
 ## MCP Servers
 - [Atlassian Remote MCP Server](https://developer.atlassian.com/platform/model-context-protocol/) - OAuth-secured remote MCP for Jira/Confluence (Claude setup + cloud endpoints).


### PR DESCRIPTION
## What

Adds [Pulse](https://github.com/chsm04/pulse) to the Plugins & Extensions section.

## About Pulse

Pulse is a local Channel plugin for Claude Code that enables push notifications into running sessions via HTTP POST.

- **Zero dependencies**: No Discord, Slack, or bot tokens needed — just `curl`
- **HTTP-native**: Any script, CI pipeline, or cron job can send notifications
- **Built on Channels protocol**: Uses Claude Code's official Channel architecture
- **Use cases**: CI/CD alerts, deploy notifications, cron monitoring, server alerts

```bash
curl -X POST http://localhost:3400/notify \
  -H "Content-Type: application/json" \
  -d '{"text":"Deploy complete ✓","source":"deploy","level":"info"}'
```

TypeScript + Bun, MIT license.