### PR TITLE
Add claude-token-analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [claude-token-analyzer](https://github.com/li195111/claude-token-analyzer) | li195111 | Diagnoses token waste in Claude Code sessions: 6 anomaly types, cost audit, trend forecasting. Fully local, plugin-native. |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
-| [claude-token-analyzer](https://github.com/li195111/claude-token-analyzer) | li195111 | Diagnoses token waste in Claude Code sessions: 6 anomaly types, cost audit, trend forecasting. Fully local, plugin-native. |
+| [Claude Token Analyzer](https://github.com/li195111/claude-token-analyzer) | li195111 | Diagnoses token waste in Claude Code sessions: 6 anomaly types, cost audit, trend forecasting. Fully local, plugin-native |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q1 |
 
 ## Installation
 


### PR DESCRIPTION
## New Plugin: claude-token-analyzer

Diagnoses token waste in Claude Code sessions with 6 anomaly types, cost audit, and trend forecasting.

- Install: claude plugin install claude-token-analyzer
- Fully local -- parses ~/.claude JSONL files into SQLite, nothing leaves your machine
- MIT licensed

GitHub: https://github.com/li195111/claude-token-analyzer