### PR TITLE
Add Toprank

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Toprank](https://github.com/nowork-studio/toprank) | nowork-studio | Claude Code plugin for SEO, Google Ads, content writing, and CMS audits |
 
 ## MCP Servers
 


### PR DESCRIPTION
## Summary
- add `nowork-studio/toprank` to Plugins & Extensions
- describe it as a Claude Code plugin for SEO, Google Ads, content writing, and CMS audits

## Why it fits
Toprank is an installable Claude Code plugin and belongs alongside the other plugin and marketplace entries in this list.