### PR TITLE
Add fabbo-ai-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator) | fabbo-ai | Claude Code / Codex skill that drives a real Playwright browser to generate AI videos and images on fabbo.ai across Veo, Sora, Kling, Wan, Luma, Runway, Midjourney, Nano Banana |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator) to Plugins & Extensions. A Claude Code / Codex SKILL.md that drives a real Playwright browser session to generate AI videos and images on [fabbo.ai](https://fabbo.ai) across Veo, Sora, Kling, Wan, Luma, Runway, Midjourney, and Nano Banana.