### PR TITLE
Add Bedrock plugin to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 
@@ -26,6 +26,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Name | Maintainer | Description |
 |------|------------|-------------|
+| [Bedrock](https://github.com/iurykrieger/claude-bedrock) | iurykrieger | Second Brain automation for Obsidian vaults — entity detection, Zettelkasten structure, and ingestion from Confluence, Google Docs, GitHub, and docling-supported files via 8 Claude Code skills |
 | [Claude Code Commands Marketplace](https://github.com/ananddtyagi/claude-code-marketplace) | ananddtyagi | Community marketplace for commands and plugins |
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |


### PR DESCRIPTION
## Summary

Adds [Bedrock](https://github.com/iurykrieger/claude-bedrock) to the **Plugins & Extensions** table.

Bedrock is a Claude Code plugin that turns any Obsidian vault into a structured Second Brain. It ships 8 skills for entity detection, ingestion (Confluence, Google Docs, GitHub, DOCX/PDF/PPTX via docling), vault compression, and sync — following adapted Zettelkasten principles.

## Why it fits

The **Plugins & Extensions** table currently lists general-purpose marketplaces and plugin packs. Bedrock adds a knowledge-management angle that's missing from the current list — plugins focused on turning vaults/notes into structured, queryable graphs rather than code-generation workflows.

## Changes

- New row in the **Plugins & Extensions** table (inserted alphabetically by name at the top).
- Bumps **Plugins listed** count `4` → `5` in the Status table.
- Updates **Last updated** to `2026-Q2`.

## Links

- Repo: https://github.com/iurykrieger/claude-bedrock
- Homepage: https://claude-bedrock.vercel.app
- Install: `/plugin marketplace add iurykrieger/claude-bedrock` then `/plugin install bedrock@claude-bedrock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)