### PR TITLE
Add ccthread to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [ccthread](https://github.com/jakemarsh/ccthread) | jakemarsh | Read, search, and have Claude summarize your Claude Code conversation logs from the CLI |
 
 ## MCP Servers
 


### PR DESCRIPTION
## Summary

Adds [ccthread](https://github.com/jakemarsh/ccthread) to Plugins & Extensions.

ccthread is a Claude Code plugin + standalone CLI that reads Claude Code conversation logs from `~/.claude/projects/` and turns each session's `.jsonl` into clean markdown. Install via `/plugin marketplace add jakemarsh/ccthread`, or grab the standalone binary via the installer script.

Tagline: *Read, search, and have Claude summarize your Claude Code conversation logs from the CLI.*

## License

MIT.