### PR TITLE
Add Lore plugin to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Lore](https://github.com/yacb2/lore) | yacb2 | Living knowledge graph for software projects — typed graph (modules, capabilities, flows, events, rules, decisions) backed by SQLite, with auto-invoked skills and slash commands. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [Lore](https://github.com/yacb2/lore), a living knowledge graph for software projects, to the Plugins & Extensions table.

**What it does:** Captures business logic (modules, capabilities, flows, events, rules, decisions) as a typed graph backed by SQLite. Auto-invoked skills and slash commands let coding agents query and maintain it across sessions.

**Distribution:** Claude Code plugin marketplace. License: MIT.

Following the table format and contributing guidelines (single suggestion, period at end of description).