### PR TITLE
Add koreanpulse — Korean equity intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [koreanpulse](https://github.com/whdrnr2583-cmd/koreanpulse) | License key + DART API key | Korean equity intelligence — DART filings, foreign-holder 5%-rule flows (BlackRock / Vanguard / Norges / GIC + 16 more), Korean activist filings (KCGI / Align / ValueAct / Elliott), KRX industry news. Free public daily snapshot at koreanpulse.dev/today. |
 
 ## Editor Integrations
 


### PR DESCRIPTION
## Description
<!-- Briefly describe what you're adding to the list -->
Adds **koreanpulse** to MCP Servers section.

  - Korean equity intelligence MCP — DART filings, foreign-holder 5%-rule
    flows (BlackRock / Vanguard / Norges / GIC + 16 more), Korean activist
    filings (KCGI / Align / ValueAct / Elliott), KRX industry news.
  - Free public daily snapshot at koreanpulse.dev/today.
  - 7 MCP tools, AGPL-3.0 + commercial Cloud waitlist.
  - Hosted gateway via Smithery (no local install required).

  Repo: https://github.com/whdrnr2583-cmd/koreanpulse
## Type of contribution
<!-- Check all that apply -->
- [ ] Plugin/Extension
- [ ] MCP Server
- [ ] Editor Plugin/Integration
- [ ] Documentation/Resource
- [ ] Other (please specify)

## Submission checklist
<!-- Please check these items before submitting -->
- [ ] I have read the contribution guidelines (if any)
- [ ] The item is awesome and relevant to Claude Code
- [ ] The link is working and leads to the correct resource
- [ ] The description is clear and concise
- [ ] The item is added in the appropriate category
- [ ] The item follows the existing format
- [ ] I have verified that this item is not already in the list

## Additional context
<!-- Add any other context or screenshots about the submission here -->
