### PR TITLE
Add LLM Dark Patterns Hooks plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 
@@ -30,7 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
-| [LLM Dark Patterns Hooks](https://github.com/waitdeadai/llm-dark-patterns) | waitdeadai | 10-hook Apache-2.0 Stop/SubagentStop/PreCompact suite for runtime enforcement of documented LLM dark patterns (DarkBench, AAAI 2026). Bash + jq, out-of-band judge, 168-fixture stress test. |
+| [LLM Dark Patterns Hooks](https://github.com/waitdeadai/llm-dark-patterns) | waitdeadai | Stop-hook suite blocking documented LLM dark patterns (sycophancy, false-success, fabricated cites). Bash + jq judge. |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [LLM Dark Patterns Hooks](https://github.com/waitdeadai/llm-dark-patterns) | waitdeadai | 10-hook Apache-2.0 Stop/SubagentStop/PreCompact suite for runtime enforcement of documented LLM dark patterns (DarkBench, AAAI 2026). Bash + jq, out-of-band judge, 168-fixture stress test. |
 
 ## MCP Servers
 


### PR DESCRIPTION
> **Update 2026-05-16** — five days after this PR was opened, the suite is now at v1.0.0, with 31 wired hooks (up from 10 at PR-open / 28 at the earlier May-11 update). PR #10 merging the v1.0.0 description into `main` of `waitdeadai/llm-dark-patterns` landed today. A self-hosted marketplace is now live at `github.com/waitdeadai/claude-plugins` — install verified end-to-end on Claude Code v2.1.143:
>
> ```bash
> claude plugin marketplace add waitdeadai/claude-plugins
> claude plugin install llm-dark-patterns@waitdeadai-plugins
> ```
>
> The Anthropic community marketplace v1.0.0 submission is in queue today (`anthropics/claude-plugins-official#1887` tracks the Published-but-not-yet-listed delay shared by many publishers). The plugin is installable today via the self-hosted route regardless. Per-hook security audit lives at `SECURITY_AUDIT.md`; threat model at `README.md` §Threat model.

---

## Summary

Adds the **LLM Dark Patterns Hooks** plugin to the Plugins & Extensions table. Bumps the Plugins listed counter from 4 → 5. Bumps the Status table's `Last updated` from 2025-Q2 → 2026-Q2.

## What it is

An Apache-2.0 hook suite for Claude Code that targets documented LLM dark patterns at the `Stop` / `SubagentStop` / `TaskCreated` / `TaskCompleted` / `PreToolUse` lifecycle events. The judge is bash + jq — out-of-band, deterministic, and no LLM participates in the verdict path. That means prompt text inside the model context cannot directly rewrite the judge, while lexical evasion, hook misconfiguration, and runtime bypass remain explicit limitations.

**Suite expanded substantially after PR opened (2026-05-11)**:

| Metric | At PR open | Now (HEAD) |
|---|---|---|
| Hooks | 10 | **28** |
| Stress fixtures | 168 | **337** |
| Pack loader unit tests | 0 | 17 |
| Locale packs | inline only | 6 (en/es/pl/de/fr/pt) |
| Evidence binary categories | inline only | 9 (app-dev, devops, k8s, cloud, database, etc.) |
| Destructive surface packs | inline only | 7 (filesystem, container, git-protected, config-overwrite, cloud-prod, database, service) |
| Branches in suite taxonomy | 3 | 6 (+ multi-agent orchestration, agentic safety, power-user polish) |

## Coverage maps to academic literature

- **DarkBench** (Kran et al. 2025, ICLR 2025, [arXiv:2503.10728](https://arxiv.org/abs/2503.10728))
- **DarkBench+** (Liu et al. 2026, AAAI 2026 main conference, [ojs.aaai.org/AAAI/article/view/41103](https://ojs.aaai.org/index.php/AAAI/article/view/41103) — ~40 LLMs, 10 categories)
- **AAAI 2026 Spring Symposium** (Li et al. 2026, [arXiv:2604.04735](https://arxiv.org/abs/2604.04735) — sycophancy at 91.7% prevalence)
- **DarkPatterns-LLM** ([arXiv:2512.22470](https://arxiv.org/abs/2512.22470), Dec 2025)
- **Anthropic multi-agent research** (Jun 2025) + **arXiv:2604.14228** (Apr 2026, "silent mistakes are the dominant failure mode")
- **AgentLeak** ([arXiv:2602.11510v2](https://arxiv.org/html/2602.11510v2), Mar 2026) — credential leak benchmark
- **Anthropic Claude Opus 4.6 Sabotage Risk Report** — passive research sandbagging
- **Pataranutaporn et al. 2024** ([arXiv:2408.04681](https://arxiv.org/abs/2408.04681)) — false-memory recall

## Receipts

- 337-fixture stress suite at [`tests/stress/`](https://github.com/waitdeadai/llm-dark-patterns/tree/main/tests/stress) — CI green at HEAD
- 17-test pack loader unit tests at [`tests/test-pack-loader.sh`](https://github.com/waitdeadai/llm-dark-patterns/blob/main/tests/test-pack-loader.sh)
- Plugin format compliant: ships `.claude-plugin/plugin.json` + `hooks/hooks.json` for the standard Claude Code plugin marketplace
- Apache-2.0, single bash file per hook (~50-150 lines), `jq` is the only dependency for most hooks (one uses `python3`)

## CLAUDE.md compliance

Per your `CLAUDE.md`:
- **Minimal deltas**: 1 file changed, 2 insertions / 2 deletions. Just the table row + counter bump + Last updated bump.
- **Receipt**: `Receipt: 8569dd2`
- **Workflow run**: manual contribution, not workflow-generated.
- **Not a public API change**: documentation-only edit.

## Repo links

- Plugin (umbrella, 28 hooks): https://github.com/waitdeadai/llm-dark-patterns
- Methodology (with citation map): https://github.com/waitdeadai/llm-dark-patterns/blob/main/METHODOLOGY.md
- Single most polished hook (the `no-vibes` standalone repo, HN target): https://github.com/waitdeadai/no-vibes
- Loadable-packs roadmap: https://github.com/waitdeadai/llm-dark-patterns/blob/main/ROADMAP.md

