### PR TITLE
Add AgentsAtlas to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [AgentsAtlas](https://github.com/AvinashP/AgentsAtlas) | AvinashP | Workflow plugin — 8 slash commands and 16 dev skills; runs each plan in a fresh-context subagent. Also ships as Codex skills. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds **AgentsAtlas** to the Plugins & Extensions table.

[AgentsAtlas](https://github.com/AvinashP/AgentsAtlas) is a minimal end-to-end workflow plugin for Claude Code (also available as Codex skills):

- 8 slash commands: `/atlas:init`, `/atlas:plan`, `/atlas:execute`, `/atlas:status`, `/atlas:sync`, `/atlas:triage`, `/atlas:review`, `/atlas:complete`
- 16 development "discipline" skills (debugging, testing, verifying, refactoring, security-audit, …)
- `/atlas:execute` runs each 3–5-task plan in a fresh subagent so context doesn't degrade across a long run; `STATE.md` / `ROADMAP.md` carry continuity
- Install: `npx agents-atlas --global` — also on npm as `agents-atlas`
- MIT licensed; no telemetry, no network calls beyond Anthropic, no bypass-permissions requirement

Also bumps the Status table (plugin count 4 → 5, last-updated quarter) to reflect the addition.