### PR TITLE
Add pluginpool (10 productivity plugins, marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [pluginpool](https://github.com/mturac/pluginpool) | mturac | Ten focused Claude Code plugins for everyday developer productivity (commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge). 89 hermetic tests, Python stdlib only at runtime, MIT |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [pluginpool](https://github.com/mturac/pluginpool) to *Plugins & Extensions*.

Ten focused Claude Code plugins for everyday developer productivity: commit-narrator, pr-storyteller, test-gap, deps-doctor, env-lint, secret-guard, standup-gen, todo-harvest, flaky-detector, changelog-forge.

Each plugin's core is a deterministic Python helper (stdlib only at runtime) wrapped as a Claude Code slash command. **89 hermetic tests across the suite, MIT.** Install all at once via marketplace: `/plugin marketplace add mturac/pluginpool`.