### PR TITLE
Add DoD-Guard to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [DoD-Guard](https://github.com/atoslins/dod-guard) | atoslins | Definition of Done as an executable barrier — 7 adversarial subagents + 11 detectors + 5 hooks that stop premature "done" claims |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [DoD-Guard](https://github.com/atoslins/dod-guard) to the **Plugins & Extensions** table.

## What it does

DoD-Guard enforces the Definition of Done as an executable barrier for Claude Code. It targets the specific failure mode where LLM-driven coding assistants declare tasks "done" while leaving stubs, tautological tests, unverified claims, or silent regressions.

Five reinforcing layers:

- **11 deterministic detectors** (bash + python AST, no LLM) — stubs, TODOs, empty functions, suspicious returns, tautological tests, NotImpl markers, coverage delta, test-runner auto-detection.
- **5 lifecycle hooks** — `PostToolUse` blocks bad edits; `Stop` refuses to release the turn while DoD is unmet, with proper `stop_hook_active` loop prevention; `--no-verify` rejected outright.
- **7 read-only adversarial subagents** — completeness, test quality, e2e proof, regressions, hostile review, claim validation, plus a `final-judge` aggregator (one FAIL = FAIL).
- **8 slash commands** — `/dod:init`, `/dod:verify`, `/dod:audit`, `/dod:report`, `/dod:stubs`, `/dod:tests`, `/dod:checklist`, `/dod:confess`.
- **4 skills** that reframe orchestrator behavior in any project that has `.dod-guard.json`.

## Verification

- 94 test assertions across 4 suites pass.
- `shellcheck -x` clean on every shell script.
- `claude plugin validate` passes for both `plugin.json` and `marketplace.json`.
- GitHub Actions CI runs all of the above on every push and PR.
- Released as v0.1.0 with MIT license.

Repo: https://github.com/atoslins/dod-guard
Release: https://github.com/atoslins/dod-guard/releases/tag/v0.1.0