### PR TITLE
Add Perseus — live context engine for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Perseus](https://github.com/tcconnally/perseus) | tcconnally | Live context engine — resolves @query/@services/@waypoint directives into CLAUDE.md before session start. Hook installer for `.claude/settings.json`. |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
-| [Perseus](https://github.com/tcconnally/perseus) | tcconnally | Live context engine — resolves @query/@services/@waypoint directives into CLAUDE.md before session start. Hook installer for `.claude/settings.json`. |
+| [Perseus](https://github.com/tcconnally/perseus) | tcconnally | Live context engine — resolves `@query`/`@services`/`@waypoint` directives into `CLAUDE.md` before session start. Hook installer for `.claude/settings.json`. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds Perseus to the Plugins & Extensions table (and bumps the status counter).

Perseus is an MIT-licensed live context engine that resolves directives (`@query`, `@services`, `@waypoint`, `@agora`, and 18 others) inside `.perseus/context.md` and writes the result to `CLAUDE.md` — or whatever file the assistant reads at session start. The assistant never sees directive syntax; it sees a document of verified facts.

- Repo: https://github.com/tcconnally/perseus
- PyPI: `pip install perseus-ctx`
- Site: https://perseus.observer
- Hook installer: `perseus install --target claude-code` drops SessionStart hooks into `.claude/settings.json`
- MCP server façade: `perseus mcp serve` exposes 13 directives as MCP tools, so it could also fit the MCP Servers table — let me know if you'd prefer that placement instead.

Currently v1.0.3, 596 tests, listed on the MCP Registry, Anthropic Skills marketplace PR open ([anthropics/skills#1193](https://github.com/anthropics/skills/pull/1193)).