### PR TITLE
Add app_dev_zero_to_online to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [app_dev_zero_to_online](https://github.com/HyperDevApp/app_dev_zero_to_online) | HyperDevApp | Guided nine-phase dialog that takes a project from zero to a live, online app. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adding [HyperDevApp/app_dev_zero_to_online](https://github.com/HyperDevApp/app_dev_zero_to_online) — a public, MIT-licensed Claude Code plugin that walks a project from zero to a live, online app via a nine-phase, twenty-six-step guided dialog.

- Slash commands: `/app-dev`, `/app-dev-status`, `/app-dev-reset`
- Data-driven workflow (`data/app_development_steps.json`) editable without touching code
- Install via `/plugin marketplace add HyperDevApp/app_dev_zero_to_online`

The entry follows the existing table format and adheres to the contributing guidelines (single suggestion, period-terminated description).