### PR TITLE
Add Knowledge Graph plugin to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Knowledge Graph](https://github.com/mironmax/claudecode-plugins) | mironmax | Persistent cross-session memory plugin — nodes, typed edges, auto-compaction. Local MCP server + visual graph editor. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds the Knowledge Graph plugin for Claude Code — a persistent memory layer using a local Python MCP server, skills, and a D3.js visual editor. Survives across sessions so Claude doesn't re-derive context.

- Repo: https://github.com/mironmax/claudecode-plugins
- Marketplace: maxim-plugins
- Plugin: knowledge-graph

Format follows existing rows in the Plugins & Extensions table.