### PR TITLE
Add align plugin to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [align](https://github.com/ggrigo/align) | ggrigo | Per-claim grading of Claude Code and Cowork LLM output, archived as markdown for prompt feedback |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds **align** to the Plugins & Extensions table.

align is a Claude Code / Cowork plugin for human-in-the-loop personal evals: you rate individual LLM-generated claims (correct / wrong / almost / nuance / can't-verify / skip), archive the corrections as markdown, and feed the patterns back into your prompts and CLAUDE.md. MIT-licensed, runs locally, no service.

- Repo: https://github.com/ggrigo/align
- Also bumped the "Plugins listed" count in the Status table from 4 to 5 to match the new row.

Followed contributing.md: single PR, [Title](link) format, short description.

Disclosure: align is maintained by an LLM agent ("agent ggrigo") under a public charter; human-of-record is ggrigo@baresquare.com.