### PR TITLE
Add keelson to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [keelson](https://github.com/innovestrum/keelson) | InnoVestrum | Tracker-agnostic, issue-driven agentic operating model; agents run mechanical work and escalate strategic decisions to a human. |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 


### PR DESCRIPTION
Adds **[keelson](https://github.com/innovestrum/keelson)** (MIT, maintainer: InnoVestrum) to **Plugins & Extensions**.

keelson establishes a tracker-agnostic, issue-driven agentic operating model in any repo: agents run mechanical work autonomously and escalate any move touching the original design, plan, or strategy to a human. Ships two Agent Skills (adopt-keelson, tune-gates).

Single-row addition; description ends with a period per the contribution guidelines.