### PR TITLE
Add xberg plugins marketplace and MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Kreuzberg Plugins](https://github.com/kreuzberg-dev/plugins) | Kreuzberg, Inc. | Document intelligence: local extraction (91+ formats with OCR), web crawling (HTML→Markdown), and managed cloud extraction |
 
 ## MCP Servers
 
@@ -40,6 +41,8 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) | None (local) | Document extraction — text, tables, metadata, images from 91+ formats with OCR |
+| [Kreuzcrawl](https://github.com/kreuzberg-dev/kreuzcrawl) | None (local) | Web crawling and scraping — HTML→Markdown with headless-Chrome fallback |
 
 ## Editor Integrations
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
-| [Kreuzberg Plugins](https://github.com/kreuzberg-dev/plugins) | Kreuzberg, Inc. | Document intelligence: local extraction (91+ formats with OCR), web crawling (HTML→Markdown), and managed cloud extraction |
+| [xberg Plugins](https://github.com/xberg-io/plugins) | Kreuzberg, Inc. | Document intelligence: local extraction (97+ formats with OCR), web crawling (HTML→Markdown), and managed cloud extraction |
 
 ## MCP Servers
 
@@ -41,8 +41,8 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
-| [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) | None (local) | Document extraction — text, tables, metadata, images from 91+ formats with OCR |
-| [Kreuzcrawl](https://github.com/kreuzberg-dev/kreuzcrawl) | None (local) | Web crawling and scraping — HTML→Markdown with headless-Chrome fallback |
+| [xberg](https://github.com/xberg-io/xberg) | None (local) | Document extraction — text, tables, metadata, images from 97+ formats with OCR |
+| [crawlberg](https://github.com/xberg-io/crawlberg) | None (local) | Web crawling and scraping — HTML→Markdown with headless-Chrome fallback |
 
 ## Editor Integrations
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add Kreuzberg plugin marketplace and MCP server listings
<code>📝 Documentation</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Adds three entries:

- **Plugins & Extensions**: `kreuzberg-dev/plugins` — marketplace shipping three document-intelligence plugins (kreuzberg, kreuzcrawl, kreuzberg-cloud) for Claude Code / Codex / Cursor / Gemini / Factory / Copilot / opencode.
- **MCP Servers**: `kreuzberg` and `kreuzcrawl` — both ship MCP servers via a `mcp` subcommand on their Rust CLIs. Local, no auth.

License: MIT.
Maintainer: Kreuzberg, Inc. <support@kreuzberg.dev>

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add Kreuzberg Plugins marketplace entry under Plugins &amp; Extensions.
• Add Kreuzberg and Kreuzcrawl entries under MCP Servers with local/no-auth notes.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  R["README.md"] --> P["Plugins & Extensions"] --> KP["Kreuzberg Plugins"]
  R --> M["MCP Servers"] --> KB["Kreuzberg MCP"]
  M --> KC["Kreuzcrawl MCP"]
  subgraph Legend
    direction LR
    _doc["Documentation"] ~~~ _list["Catalog section"] ~~~ _entry["New entry"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR’s approach (adding direct README entries for discoverability) is appropriate for a curated index. The only considerations are consistency (table ordering/format) and ensuring the descriptions match the repository capabilities, but no different architectural approach is warranted.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>README.md</strong> <code>Add Kreuzberg plugin marketplace and MCP server entries</code> <code>+3/-0</code></summary>

<br/>

>Add Kreuzberg plugin marketplace and MCP server entries
>
><pre>
>• Adds a new listing for the Kreuzberg Plugins marketplace under Plugins &amp; Extensions. Adds two MCP Server listings (Kreuzberg and Kreuzcrawl) noting local/no-auth usage and summarizing capabilities.
></pre>
>
><a href='https://github.com/jmanhype/awesome-claude-code/pull/54/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5'>README.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>