### PR TITLE
Add Poppify MCP to the MCP Servers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |
@@ -39,6 +39,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Token | Repos, issues, PRs, workflows |
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
+| [Poppify MCP](https://github.com/Poppify/poppify-claude-plugin) | apiKey / HTTP | Photo to TikTok / Instagram Reels / YouTube Shorts / Facebook video — 27 tools, $0.06/render, 50 free seeds |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
 
 ## Editor Integrations


### PR DESCRIPTION
## Summary

Adds [Poppify MCP](https://github.com/Poppify/poppify-claude-plugin) to the **MCP Servers** table, alphabetically inserted between Notion MCP and Supabase MCP. Updates the Status metric (MCP servers: 5 → 6).

## What Poppify is

An MCP server for photo-to-vertical-video — converts 1–10 photos into a captioned 15/30/60s reel for TikTok, Instagram Reels, YouTube Shorts, and Facebook. 27 MCP tools (\`register\`, \`start_session_from_photos\`, \`update_slides\`, \`set_audio\`, \`generate_image\`, \`generate_music\`, \`generate_voiceover\`, \`confirm\`, \`get_result\`, etc.) plus 4 skills and 3 slash commands when installed as a Claude Code plugin.

\$0.06 per render. 50 free seeds on signup. No subscription.

## Files changed

- \`README.md\`: 2 lines (one new table row + Status counter bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)