### PR TITLE
Add Slime to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Slime](https://github.com/bitqs/slime) | bitqs | Renders your real session as a turn-based RPG — statusline HUD + PixiJS arena, zero session impact |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [Slime](https://github.com/bitqs/slime) — renders your real Claude Code session as a turn-based RPG: a statusline HUD + a PixiJS browser arena, driven entirely by hooks as a pure observer (zero impact on the session, zero runtime dependencies, MIT).

- Live demo: https://slime-arena-demo.shuangqu.workers.dev
- Install: `/plugin marketplace add bitqs/slime` → `/plugin install slime@slime`

One row added to the Plugins & Extensions table, matching the existing format.