### PR TITLE
Add TG Bridge — two-way Telegram bridge plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [TG Bridge](https://github.com/IfeyChan702/claude-tg-bridge) | IfeyChan702 | Two-way Telegram bridge: replies pushed to your phone, TG messages continue the session |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds **TG Bridge** to Plugins & Extensions: a plugin that pushes Claude Code replies to a private Telegram bot and turns TG messages into session events, so you can continue tasks from your phone.

- Zero-dependency Python stdlib; the only network surface is `api.telegram.org`
- Outbound via Stop/Notification hooks (auto-wired through `${CLAUDE_PLUGIN_ROOT}`), inbound via a long-polling monitor
- Multi-bot: one bot per session, parallel sessions from separate TG chats

Repo: https://github.com/IfeyChan702/claude-tg-bridge

Follows the existing table format; checked for duplicates (no Telegram entry present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)