### PR TITLE
Add screenshot-janitor to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [screenshot-janitor](https://github.com/MECoban/screenshot-janitor) | MECoban | Per-session screenshot cleanup — asks to move a session's screenshots to the Trash before you leave (macOS + Linux, zero dependencies). |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [screenshot-janitor](https://github.com/MECoban/screenshot-janitor) to the **Plugins & Extensions** table.

Per-session screenshot cleanup for Claude Code — before you leave a session it asks once whether to move that session's screenshots to the Trash. macOS + Linux, recoverable deletion, zero dependencies. Follows the existing table format.