### PR TITLE
Add NotFair – Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [NotFair](https://github.com/nowork-studio/NotFair) | nowork-studio | Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a great reference for the Claude Code ecosystem.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) (~2.9k stars, MIT), an open-source set of Claude Code agent skills for marketing work. It covers SEO/GEO, content writing, and paid advertising, and it connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

It fits naturally in the Plugins & Extensions section alongside the other plugin entries. Happy to reword, move, or trim the description if you'd prefer a different format.