### PR TITLE
Add Synder Importer MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) | API Token | Import CSV/XLSX accounting data into QuickBooks Online or Xero |
 
 ## Editor Integrations
 


### PR DESCRIPTION
Adds a row to the **MCP Servers** table for the Synder Importer MCP server.

**What**
- [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com).
- npm: [@cloudbusiness/gl-importer-mcp](https://www.npmjs.com/package/@cloudbusiness/gl-importer-mcp) (v0.1.1, published with provenance + `mcpName`)
- Official MCP Registry: `com.synder/gl-importer-mcp` (DNS-authenticated under synder.com)
- License: MIT

**Install**
\`\`\`bash
npx -y @cloudbusiness/gl-importer-mcp
\`\`\`

Per contributing.md guidelines: kept the row format, ended description with implicit period (table cell).