### PR TITLE
Add ax MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |
@@ -35,6 +35,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Name | Auth | Coverage |
 |------|------|----------|
+| [ax](https://github.com/Necmttn/ax) | Local | Recall, session drill-down, cost analytics, skill/hook usage, dispatches, and workflow evidence across Claude Code, Codex, Pi, OpenCode, and Cursor histories |
 | [Atlassian Remote MCP](https://developer.atlassian.com/platform/model-context-protocol/) | OAuth | Jira, Confluence |
 | [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Token | Repos, issues, PRs, workflows |
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |


### PR DESCRIPTION
Adds ax to the MCP Servers table and updates the MCP server count.

Validation:
- `git diff --check`
- `rg -n "Necmttn/ax" README.md`

---

_Generated with [ax](https://github.com/Necmttn/ax)._
