### PR TITLE
Add t3d to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [t3d](https://github.com/coolsocket/t3d) | coolsocket | DDD + TDD harness; 5 hooks enforce Domain-layer purity and cross-context rules, 4 skills scaffold bounded contexts and audit drift. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [t3d](https://github.com/coolsocket/t3d) — a small Claude Code plugin (5 hooks + 4 skills + project templates) that enforces DDD + TDD discipline at edit time.

Format follows existing table convention.

Verification:
```
/plugin marketplace add coolsocket/t3d
/plugin install t3d
/t3d-init
```