### PR TITLE
Add Hephaestus

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Hephaestus](https://github.com/agentlas-ai/Hephaestus) | agentlas-ai | Local agent runtime for Claude Code, Codex, and Cursor with skills, commands, memory, and policy gates |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q2 |
 
 ## Installation
 


### PR DESCRIPTION
Adds Hephaestus to the Plugins & Extensions section and updates the listed plugin count.

Hephaestus is a local agent runtime for Claude Code, Codex, and Cursor with skills, commands, memory, and policy gates.