### PR TITLE
Add AgentsCoin to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Name | Auth | Coverage |
 |------|------|----------|
+| [AgentsCoin MCP](https://github.com/axiosdevs/agentscoin-mcp) | None | Wallet, faucet, send, token create/trade on a live EVM chain |
 | [Atlassian Remote MCP](https://developer.atlassian.com/platform/model-context-protocol/) | OAuth | Jira, Confluence |
 | [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Token | Repos, issues, PRs, workflows |
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |


### PR DESCRIPTION
Adds AgentsCoin to the MCP Servers list.

AgentsCoin gives an AI agent its own money on a live EVM chain: create a wallet, get AGENT from the faucet, send, and create/trade tokens. Ships as an MCP server (npm `agentscoin-mcp`, `npx agentscoin-mcp`, remote URL https://agents-coin.com/mcp) plus a one-click Claude Desktop extension.

- Repo: https://github.com/axiosdevs/agentscoin-mcp
- Site: https://agents-coin.com
- Tools (8): network_info, create_wallet, mine (faucet), balance, send, create_coin, add_liquidity, swap.

One entry, inserted alphabetically, matching the existing table format.