### PR TITLE
Add Reflex to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |
@@ -40,6 +40,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [Reflex](https://reflexmcp.com) | API key | Browser automation, parallel isolated sessions, runs locally |
 
 ## Editor Integrations
 


### PR DESCRIPTION
Adds Reflex to the MCP Servers table and bumps the count to 6.

Reflex is a local MCP server that drives your own Chrome for any MCP client like Claude Desktop and Cursor. It finishes browsing tasks about 3.5x faster end to end than Playwright MCP, on fewer round trips and tokens, can run many isolated browsers in parallel, and keeps pages on your machine. Free tier, no card.

Homepage: https://reflexmcp.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)