### PR TITLE
Add Smartin Compass to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Smartin Compass](https://github.com/Smartin-Martin/smartin-marketplace) | Smartin-Martin | Catch raw ideas as they come, surface which are worth checking, and get one weekly Finding — local-first and free |
 
 ## MCP Servers
 


### PR DESCRIPTION
## Description
Adds Smartin Compass — a free, local-first plugin that catches raw ideas as they come, surfaces which are worth checking, and produces one weekly Finding worth forwarding. Built on the Smartin Compass 6-tile method.

Type of contribution: Plugin / marketplace.

Marketplace repo: https://github.com/Smartin-Martin/smartin-marketplace
Install: /plugin marketplace add Smartin-Martin/smartin-marketplace then /plugin install smartin-compass

I verified the link works, the entry follows the existing table format, and it is not already listed.