### PR TITLE
Add ModelRunner Agent Skills to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [ModelRunner Agent Skills](https://github.com/modelrunner/agent-skills) | modelrunner | App Store & Google Play screenshots and iOS demo assets generated with AI via the ModelRunner MCP; portable across Claude Code, Codex, Cursor & Copilot. |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |


### PR DESCRIPTION
Adds **[ModelRunner Agent Skills](https://github.com/modelrunner/agent-skills)** to the *Plugins & Extensions* table.

Two portable, MIT-licensed skills that generate real product visuals through ModelRunner's public MCP server (`mcp.modelrunner.run`):

- **app-store-screenshots** — raw app captures → a cohesive App Store / Google Play screenshot set (device frames, on-brand backgrounds, ASO headlines).
- **ios-demo-assets** — bulk on-spec demo images loaded into Xcode's `Assets.xcassets` and the Simulator's Photos library.

Authored once as `SKILL.md` and built for Claude Code, Codex, Cursor & Copilot. Also live on the Claude Code plugin marketplace as `modelrunner/agent-skills`.

Follows the contributing format (single suggestion, `[Title](link)` + description ending in a period).