### PR TITLE
Add praetor to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [praetor](https://github.com/luoxianzi/praetor) | luoxianzi | Claude plans, the Codex CLI executes, and a binding fresh-context judge decides what merges — acceptance criteria frozen in git before the executor runs; Legion Mode runs 2–5 parallel workers behind an integration judge |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds **praetor** — what sets it apart from the first-party codex bridge: a binding, independent, fresh-context judge. Acceptance criteria are frozen in git *before* the executor runs, and the judge — which never saw the planning conversation — returns a PASS/FAIL the planner cannot override. Legion Mode runs 2–5 parallel Codex workers in isolated git worktrees behind a mandatory integration judge (2.84× measured on a real 3-lane run). Zero-config; the README benchmark table includes its own failures on purpose. MIT.

Repo: https://github.com/luoxianzi/praetor · Why-a-judge write-up: https://github.com/luoxianzi/praetor/blob/main/docs/WHY-A-JUDGE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)