### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Memory/context tools | 1 |
+| Last updated | 2026-Q3 |
 
 ## Installation
 
@@ -40,6 +41,12 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+
+## Memory & Context Tools
+
+| Name | Runtime | Description |
+|------|---------|-------------|
+| [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) | Rust CLI / agent skill | Framework-agnostic, local-first memory lifecycle layer for AI agents with portable skill guidance, recall, forgetting, audit, consolidation, and Claude Code bridge patterns. |
 
 ## Editor Integrations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome Claude Code
 
-A list of Claude Code plugins, MCP servers, editor integrations, and learning resources.
+A list of Claude Code plugins, MCP servers, memory and context tools, editor integrations, and learning resources.
 
 ## Status
 
@@ -10,7 +10,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Memory/context tools | 1 |
+| Memory & Context Tools | 1 |
 | Last updated | 2026-Q3 |
 
 ## Installation


### PR DESCRIPTION
## Summary
- Adds Tree Ring Memory as a memory/context tool for agentic coding workflows.
- Introduces a small Memory & Context Tools section instead of placing it under MCP Servers or Claude-only plugins.
- Updates the status table count and timestamp.

## Validation
- Searched existing issues and PRs for Tree Ring / tree-ring / memory; found related memory submissions but no Tree Ring duplicate.
- Ran .

Disclosure: I maintain Tree Ring Memory.