### PR TITLE
Add Data Olympus

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |
@@ -36,6 +36,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Name | Auth | Coverage |
 |------|------|----------|
 | [Atlassian Remote MCP](https://developer.atlassian.com/platform/model-context-protocol/) | OAuth | Jira, Confluence |
+| [Data Olympus](https://github.com/knaisoma/data-olympus) | Local | Governed project knowledge, reviewed learning proposals, in-force retrieval |
 | [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Token | Repos, issues, PRs, workflows |
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |


### PR DESCRIPTION
## Description

Adds Data Olympus to the MCP Servers section. Data Olympus is a local governed project-knowledge MCP server for AI coding agents, with reviewed learning proposals and in-force retrieval.

## Type of contribution

- [ ] Plugin/Extension
- [x] MCP Server
- [ ] Editor Plugin/Integration
- [ ] Documentation/Resource
- [ ] Other (please specify)

## Submission checklist

- [x] I have read the contribution guidelines (if any)
- [x] The item is awesome and relevant to Claude Code
- [x] The link is working and leads to the correct resource
- [x] The description is clear and concise
- [x] The item is added in the appropriate category
- [x] The item follows the existing format
- [x] I have verified that this item is not already in the list

## Additional context

Data Olympus v0.4.0 added validity windows, supersession-aware retrieval, and in-force filtering so stale or unreviewed project guidance does not silently enter future Claude Code sessions.