### PR TITLE
Add Mr. Meeseeks plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Mr. Meeseeks](https://github.com/thephw/claude-meseeks) | thephw | Plays a Mr. Meeseeks voice line whenever Claude Code is waiting on you (done / asking / prompt-submit clips), toggleable per category |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds [Mr. Meeseeks](https://github.com/thephw/claude-meseeks) to the Plugins & Extensions table (and bumps the plugin count in the Status table from 4 to 5).

Plays a Mr. Meeseeks voice line whenever Claude Code is waiting on you — done / asking / prompt-submit clips, each toggleable via plugin config.