### PR TITLE
Add aSPARK — gated agile delivery process plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [aSPARK](https://github.com/a-lottes/aSPARK) | a-lottes | Gated agile delivery process with a full AI product team (PO, Designer, EM, Reviewer, QA, Release) and real-browser QA gates |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds aSPARK to the list.

aSPARK turns Claude Code into a gated delivery process with an AI product team. Every feature moves through five phases (Specify → Plan → Act → Review → Keep) and can only advance when the previous phase's quality gate is green. Includes real-browser QA that verifies each acceptance criterion before release, and keeps all decision artifacts inside the project as a reviewable trail.

- Repo: https://github.com/a-lottes/aSPARK
- License: MIT
- Install: `/plugin marketplace add a-lottes/aSPARK` then `/plugin install aspark@aspark`

I've matched the existing table format and added the entry to the **Plugins & Extensions** table (and bumped the plugin count in the Status table). Happy to adjust categorization.
