### PR TITLE
Add vibecheck to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [vibecheck](https://github.com/dalvgit/vibecheck) | dalvgit | Push gate that quizzes you on your own diff before every git push. |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |


### PR DESCRIPTION
Adds [vibecheck](https://github.com/dalvgit/vibecheck) to the Plugins & Extensions table.

A Claude Code plugin (and marketplace) that blocks `git push` until you pass a short multiple-choice quiz on your own outgoing diff, so AI-written code doesn't ship unread. Questions are generated from the actual diff; skipping is always offered. Zero repo setup, MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)