### PR TITLE
Add Claude Nanny (macOS menu-bar session-status HUD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Claude Nanny](https://github.com/app-brew/claude-nanny) | app-brew | macOS menu-bar HUD showing the live status (running / needs input / done / error) of every running Claude Code session across terminals |
 
 ## MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |


### PR DESCRIPTION
Adds **Claude Nanny** to the Plugins & Extensions table.

A native macOS menu-bar HUD that shows the live status (running / needs input / done / error) of every running Claude Code session across terminals. Hook-driven with a click-through overlay; installs as a Claude Code plugin and ships prebuilt universal binaries (no build step).

Repo: https://github.com/app-brew/claude-nanny