### PR TITLE
Add Parallel Search MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |
@@ -39,6 +39,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Token | Repos, issues, PRs, workflows |
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
+| [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) | None | Web search, page retrieval |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
 
 ## Editor Integrations


### PR DESCRIPTION
## Description

Adds Parallel Search MCP to the MCP Servers table and updates the status count from five to six. The hosted endpoint provides web search and page retrieval without authentication by default.

## Type of contribution

- [ ] Plugin/Extension
- [x] MCP Server
- [ ] Editor Plugin/Integration
- [ ] Documentation/Resource
- [ ] Other (please specify)

## Submission checklist

- [x] I have read the contribution guidelines
- [x] The item is relevant to Claude Code
- [x] The link is working and leads to the correct resource
- [x] The description is clear and concise
- [x] The item is added in the appropriate category
- [x] The item follows the existing format
- [x] I have verified that this item is not already in the list

## Validation

- verified the table contains six MCP rows and the status count is six
- confirmed the documentation URL returns HTTP 200
- `git diff --check`
- `npx awesome-lint` reaches the repository's existing 119 findings (missing badge, unaligned existing tables, and license-section rule); the new row follows the current table format

## Additional context

Receipt: 4acf6d45422e38a772f47489b9f4d5f9274e23fd

Workflow: Not applicable; this focused documentation change was prepared directly from current `main`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.
