### PR TITLE
Add Deposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [Deposition](https://github.com/georgedagher/deposition) | georgedagher | Local-only decision log for AI coding agents — regex-based extraction, zero API calls, nothing leaves your disk. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Local-only decision log for AI coding agents. Zero API calls — regex-based decision extraction, ChromaDB + local embeddings, nothing leaves disk. Ships as a Claude Code plugin (Stop hook + recall skill) or standalone CLI. MIT licensed.