### PR TITLE
Add dsh-plugin-cc marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
-| Last updated | 2025-Q2 |
+| Last updated | 2026-Q3 |
 
 ## Installation
 
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | cpj-dev | Claude Code marketplace bridging to the DeepSeek Harness agent for review, critique, delegation, and resumable sessions |
 
 ## MCP Servers
 


### PR DESCRIPTION
## Description
Add [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc), a Claude Code plugin marketplace that bridges to the DeepSeek Harness (`dsh`) agent for review, critique, delegation, background runs, and resumable multi-turn sessions.

## Type of contribution
- [x] Plugin/Extension
- [ ] MCP Server
- [ ] Editor Plugin/Integration
- [ ] Documentation/Resource
- [ ] Other (please specify)

## Submission checklist
- [x] I have read the contribution guidelines (if any)
- [x] The item is awesome and relevant to Claude Code
- [x] The link is working and leads to the correct resource
- [x] The description is clear and concise
- [x] The item is added in the appropriate category
- [x] The item follows the existing format
- [x] I have verified that this item is not already in the list

## Additional context
Install:

```bash
/plugin marketplace add cpj-dev/dsh-plugin-cc
/plugin install dsh@deepseek-dsh
```

Public MIT repo: https://github.com/cpj-dev/dsh-plugin-cc
