### PR TITLE
Add Agent QA MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 ## MCP Servers
 
-| Name | Auth | Coverage |
-|------|------|----------|
-| [Atlassian Remote MCP](https://developer.atlassian.com/platform/model-context-protocol/) | OAuth | Jira, Confluence |
-| [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Token | Repos, issues, PRs, workflows |
-| [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
-| [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
-| [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| Name                                                                                     | Auth               | Coverage                                                                        |
+| ---------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| [Agent QA](https://github.com/vostride/agent-qa)                                         | Provider-dependent | Natural-language web/mobile regression testing through a local stdio MCP server |
+| [Atlassian Remote MCP](https://developer.atlassian.com/platform/model-context-protocol/) | OAuth              | Jira, Confluence                                                                |
+| [GitHub MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/github)       | Token              | Repos, issues, PRs, workflows                                                   |
+| [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers)                | OAuth              | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks                             |
+| [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp)     | OAuth              | Notion workspaces                                                               |
+| [Supabase MCP](https://supabase.com/blog/supabase-mcp)                                   | OAuth / HTTP       | Supabase projects                                                               |
 
 ## Editor Integrations
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to the MCP Servers table.

Agent QA exposes a local stdio MCP server for its documented natural-language web/mobile regression workflow. The row uses `Provider-dependent` for auth rather than implying that test execution is cost-free or tied only to Claude.

I also aligned the existing MCP table so the new row does not add table-format lint failures.

## Validation

- confirmed Agent QA was not already listed or proposed by this account
- `npx -y agent-qa@0.1.21 mcp` starts and remains available for stdio client messages
- `git diff --check` passes
- `npx --yes awesome-lint` reports no errors in the changed MCP section; the repository-wide count falls from 116 on untouched `main` to 91, with the remaining findings in unrelated pre-existing sections

Disclosure: I am affiliated with Agent QA. Agent QA uses the source-available FSL-1.1-ALv2 license, not an OSI-approved open-source license; each release converts to Apache-2.0 after two years. The CLI has no software fee for permitted use, while configured model, browser, or device-provider usage may cost money.
