### PR TITLE
Add RunVouch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [RunVouch](https://github.com/runvouch/claude-plugin) | runvouch | Watchdog hooks that report unattended runs and alert on missed, failed, no-evidence, over-budget, drifting or stalled runs. |
 
 ## MCP Servers
 
@@ -40,6 +41,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [RunVouch MCP](https://runvouch.com/docs/mcp) | API key | Agent status, alerts, ack, run reports with evidence and cost. |
 
 ## Editor Integrations
 


### PR DESCRIPTION
## Description
Adds RunVouch, the watchdog for unattended AI agents: a Claude Code plugin (hooks that report Routines and headless `claude -p` runs) and its MCP server (agent status, alerts, run reports with evidence and cost).

## Type of contribution
- [x] Plugin/Extension
- [x] MCP Server
- [ ] Editor Plugin/Integration
- [ ] Documentation/Resource
- [ ] Other (please specify)

## Submission checklist
- [x] I have read the contribution guidelines (if any)
- [x] The item is awesome and relevant to Claude Code
- [x] The link is working and leads to the correct resource
- [x] The description is clear and concise
- [x] The item is added in the appropriate category
- [x] The item follows the existing format
- [x] I have verified that this item is not already in the list

## Additional context
MIT, self-hostable. Plugin: https://github.com/runvouch/claude-plugin — docs: https://runvouch.com/docs/claude-code