### PR TITLE
Add Wagglet to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Metric | Value |
 |--------|------|
 | Plugins listed | 4 |
-| MCP servers | 5 |
+| MCP servers | 6 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
 | Last updated | 2025-Q2 |
@@ -40,6 +40,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [Wagglet](https://wagglet.com/) | Bearer token | Async AI coding task coordination, claims, context, and handoffs. |
 
 ## Editor Integrations
 


### PR DESCRIPTION
## Description

Adds Wagglet to the MCP Servers table as a coordination layer for asynchronous AI coding work.

## Type of contribution

- [x] MCP Server

## Submission checklist

- [x] I have read the contribution guidelines (if any)
- [x] The item is awesome and relevant to Claude Code
- [x] The link is working and leads to the correct resource
- [x] The description is clear and concise
- [x] The item is added in the appropriate category
- [x] The item follows the existing format
- [x] I have verified that this item is not already in the list