### PR TITLE
Add HOL Plugins marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Editor | Name | Source | Notes |
 |--------|------|--------|-------|
 | VS Code | [Claude Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) | Anthropic (official) | Inline diffs, real-time edits |
-| VS Code | [Claude Code Chat](https://github.com/nishant.claude-code-chat) | Community | GUI chat front-end |
+| VS Code | [Claude Code Chat](https://marketplace.visualstudio.com/items?itemName=nishant.claude-code-chat) | Community | GUI chat front-end |
 | JetBrains | [Claude Code](https://plugins.jetbrains.com/plugin/26099-claude-code) | Anthropic (official, beta) | Interactive diffs, selection context |
 | Neovim | [claude-chat.nvim](https://github.com/ribru17/claude-chat.nvim) | Community | CLI wrapper, shares file/selection context |
 | Neovim | [claude-code.nvim](https://github.com/greggh/claude-code.nvim) | Community | Full integration inside Neovim |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 
 | Metric | Value |
 |--------|------|
-| Plugins listed | 4 |
+| Plugins listed | 5 |
 | MCP servers | 5 |
 | Editor integrations | 6 |
 | Learning resources | 5 |
@@ -30,6 +30,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [HOL Plugins](https://hol.org/plugins) | Hashgraph Online | Cross-ecosystem directory and launch surface for Claude Code plugins, MCP servers, and other AI coding-agent extensions |
 
 ## MCP Servers
 
@@ -46,7 +47,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | Editor | Name | Source | Notes |
 |--------|------|--------|-------|
 | VS Code | [Claude Code](https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code) | Anthropic (official) | Inline diffs, real-time edits |
-| VS Code | [Claude Code Chat](https://marketplace.visualstudio.com/items?itemName=nishant.claude-code-chat) | Community | GUI chat front-end |
+| VS Code | [Claude Code Chat](https://github.com/nishant.claude-code-chat) | Community | GUI chat front-end |
 | JetBrains | [Claude Code](https://plugins.jetbrains.com/plugin/26099-claude-code) | Anthropic (official, beta) | Interactive diffs, selection context |
 | Neovim | [claude-chat.nvim](https://github.com/ribru17/claude-chat.nvim) | Community | CLI wrapper, shares file/selection context |
 | Neovim | [claude-code.nvim](https://github.com/greggh/claude-code.nvim) | Community | Full integration inside Neovim |


### PR DESCRIPTION
Adds HOL Plugins to the existing Plugins & Extensions table as a cross-ecosystem directory and launch surface for Claude Code plugins, MCP servers, and other AI coding-agent extensions.

Source: https://hol.org/plugins