### PR TITLE
Add prove-it, safe-worktree and typo-fr to Plugins & Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Claude Code Plugins](https://github.com/jeremylongshore/claude-code-plugins) | jeremylongshore | Instruction-template plugins and MCP plugin packs |
 | [Multi-Agent Intelligence Marketplace](https://github.com/jmanhype/claude-code-plugins) | jmanhype | 19 plugins for trading, swarm intelligence, GitHub automation |
 | [Docker Claude Plugins](https://github.com/docker/claude-plugins) | Docker | Exposes containerized MCP servers via Docker Desktop |
+| [prove-it](https://github.com/JohnJackHouzi/prove-it) | JohnJackHouzi | Captures real evidence before an agent claims success, returning a PROVEN / NOT PROVEN verdict. |
+| [safe-worktree](https://github.com/JohnJackHouzi/safe-worktree) | JohnJackHouzi | Isolated git worktrees, a pre-commit drift guard, and cleanup that detects a squash merge. |
+| [typo-fr](https://github.com/JohnJackHouzi/typo-fr) | JohnJackHouzi | French typography enforced when writing and linted when reviewing, without touching code. |
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds three Claude Code plugins to **Plugins & Extensions**. Each is a standalone MIT repository with its own marketplace manifest, installable with `claude plugin marketplace add`.

- [prove-it](https://github.com/JohnJackHouzi/prove-it) - captures real evidence (HTTP response, browser network request, console errors, screenshot) before an agent reports success, and returns a PROVEN / NOT PROVEN / UNPROVABLE verdict.
- [safe-worktree](https://github.com/JohnJackHouzi/safe-worktree) - isolated, immediately runnable worktrees, a guard that catches the repository moving under you before a commit, and cleanup that detects a squash merge by comparing content instead of trusting `git branch --merged`.
- [typo-fr](https://github.com/JohnJackHouzi/typo-fr) - French typography applied when writing and linted when reviewing, with code, import paths, code fences and URLs protected.

The contributing guide asks for one pull request per suggestion. These three ship together as one set from the same author, so I have grouped them - happy to split into three if you prefer.

Formatting checked: rows follow the existing table columns, descriptions end with a period, no trailing whitespace.
