### PR TITLE
Add ContextStream MCP — shared project context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A list of Claude Code plugins, MCP servers, editor integrations, and learning re
 | [Google Workspace MCP](https://github.com/aekanun2020/Google-MCP-Servers) | OAuth | Sheets, Drive, Gmail, Calendar, Docs, Slides, Tasks |
 | [Notion MCP](https://www.notion.so/help/add-and-manage-connections-with-the-api#mcp) | OAuth | Notion workspaces |
 | [Supabase MCP](https://supabase.com/blog/supabase-mcp) | OAuth / HTTP | Supabase projects |
+| [ContextStream](https://github.com/contextstream/mcp-server) | OAuth / HTTP | Shared project context across Claude Code and other MCP clients |
 
 ## Editor Integrations
 


### PR DESCRIPTION
## Summary
- Add ContextStream to the MCP Servers table

**Website:** https://contextstream.io
**Hosted MCP:** https://mcp.contextstream.io/mcp
**GitHub:** https://github.com/contextstream/mcp-server
**Benchmarks:** https://contextstream.io/benchmarks

Shared project context for Cursor, Claude Code, Codex, Grok. Intelligence is not the bottleneck. Context is.

Disclosure: I work on ContextStream. Related issue: https://github.com/jmanhype/awesome-claude-code/issues/94